### PR TITLE
Base class compatibility for ConditionalContainer

### DIFF
--- a/src/ConditionalContainer.php
+++ b/src/ConditionalContainer.php
@@ -371,7 +371,7 @@ class ConditionalContainer extends Field
 
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_merge([
             'fields' => $this->fields,


### PR DESCRIPTION
DigitalCreative\\ConditionalContainer\\ConditionalContainer::jsonSerialize() must be compatible with Laravel\\Nova\\Fields\\Field::jsonSerialize()